### PR TITLE
Update DriveInfoViewModel.cs

### DIFF
--- a/BgInfo/ViewModels/DriveInfoViewModel.cs
+++ b/BgInfo/ViewModels/DriveInfoViewModel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Prism.Mvvm;
 
 namespace BgInfo.ViewModels {
@@ -14,8 +9,25 @@ namespace BgInfo.ViewModels {
         }
 
         public string Name => DriveInfo.Name;
-        public string TotalSize => GetSize(DriveInfo.TotalSize);
-        public string FreeSpace => GetSize(DriveInfo.TotalFreeSpace);
+        public string TotalSize
+        {
+            get
+            {
+                if (!DriveInfo.IsReady)
+                    return "Drive Not Ready";
+                return GetSize(DriveInfo.TotalSize);
+            }
+        }
+
+        public string FreeSpace
+        {
+            get
+            {
+                if (!DriveInfo.IsReady)
+                    return "Drive Not Ready";
+                return GetSize(DriveInfo.TotalFreeSpace);
+            }
+        }
 
         private string GetSize(long size) {
             if(size > 1 << 30)
@@ -24,3 +36,4 @@ namespace BgInfo.ViewModels {
         }
     }
 }
+


### PR DESCRIPTION
I have a removable drive that causes an exception to be thrown whenever a removable drive is not inserted. I added a DriveInfo.IsReady check to allow the system to skip over drives that aren't ready to be queried for size.